### PR TITLE
highlight `key=val`, start/stop and `\define...` syntax

### DIFF
--- a/syntaxes/context.tmLanguage
+++ b/syntaxes/context.tmLanguage
@@ -385,6 +385,12 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>(\\define[A-Za-z]*)(?![a-zA-Z])</string>
+			<key>name</key>
+			<string>storage.type.function.tex</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>(\\[A-Za-z]+)(?![a-zA-Z])</string>
 			<key>name</key>
 			<string>support.function.general.tex</string>

--- a/syntaxes/context.tmLanguage
+++ b/syntaxes/context.tmLanguage
@@ -26,12 +26,6 @@
 			<string>keyword.operator.parentheses.context</string>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>[\[\]\{\}]</string>
-			<key>name</key>
-			<string>keyword.operator.braces.context</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>\$</string>
 			<key>beginCaptures</key>
@@ -304,17 +298,62 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 		<dict>
 			<key>begin</key>
 			<string>\[</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.braces.context</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>\]</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.braces.context</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.context.group.arguments</string>
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>match</key>
+					<string>([a-zA-Z]+)(=)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function-call.context</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.assignment.context</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>,</string>
+					<key>name</key>
+					<string>punctuation.separator.arguments.context</string>
+				</dict>
+				<dict>
 					<key>include</key>
 					<string>text.tex.context</string>
 				</dict>
 			</array>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>[\[\]\{\}]</string>
+			<key>name</key>
+			<string>keyword.operator.braces.context</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/syntaxes/context.tmLanguage
+++ b/syntaxes/context.tmLanguage
@@ -206,7 +206,7 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.document.context</string>
+					<string>keyword.control.document.context</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -229,7 +229,7 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.document.context</string>
+					<string>keyword.control.document.context</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -273,7 +273,7 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.document.context</string>
+					<string>keyword.control.document.context</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -287,7 +287,7 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.document.context</string>
+					<string>keyword.control.document.context</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -363,12 +363,12 @@ Put specific matches for particular ConTeXt keyword.functions before the last tw
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.enviromnent.context</string>
+					<string>keyword.control.enviromnent.context</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.enviromnent.variable</string>
+					<string>keyword.control.enviromnent.variable</string>
 				</dict>
 			</dict>
 			<key>end</key>


### PR DESCRIPTION
The point of this pull request is to add some extra highlighting for the common sorts of syntax in ConTeXt. There are three commits, one for each bit of syntax:

- `key=value` syntax
- `\define...` syntax
- `\start...` and `\stop...` syntax

The `key=value` part is (in my opinion) a clear improvement and really should be added.

The `define` part is a bit subjective, but I would argue it makes sense given the huge number of commands like that in ConTeXt and how common using that kind of interface is.

The start/stop one is the most subjective I would say. A command like `\starttext` is not exactly a `keyword.control` really. But I wanted to add some special treatment to start/stop delimiters to distinguish them from other commands, and the `keyword.control` scope seemed to be one that is generally styled differently to anything else in the syntax so far.